### PR TITLE
Allow running postgres on root + fix clippy lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/.idea
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,19 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 glob = "0.3"
-lazy_static = "1.4.0"
-nix = "0.22"
+nix = "0.26"
 tempdir = "0.3"
 thiserror = "1.0"
 tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
+once_cell = "1"
 
 [dev-dependencies]
-test-env-log = { version = "0.2", default-features = false, features = ["trace"] }
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tokio = { version = "1.8", features = ["parking_lot", "rt", "rt-multi-thread", "sync", "io-util", "process", "macros", "fs"], default-features = false }
 tokio-postgres = "0.7"
-tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 [features]
 default = []

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,6 +52,9 @@ pub enum TmpPostgrustError {
     /// Error when the cache directory cannot be created.
     #[error("failed to create cache directory")]
     CreateCacheDirFailed(#[source] std::io::Error),
+    /// Error when `cp` fails for the initialized database.
+    #[error("updating directory permission to non-root failed")]
+    UpdatingPermissionsFailed(ProcessCapture),
 }
 
 /// Result type for `TmpPostgrustError`, used by functions in this crate.

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,7 +5,7 @@ use which::which;
 
 /// Addtional file system locations to search for binaries
 /// if `initdb` and `postgres` are not in the $PATH.
-const SEARCH_PATHS: [&'static str; 5] = [
+const SEARCH_PATHS: [&str; 5] = [
     "/usr/local/pgsql",
     "/usr/local",
     "/usr/pgsql-*",
@@ -21,12 +21,12 @@ pub(crate) fn find_postgresql_command(dir: &str, name: &str) -> Result<PathBuf, 
 
     // Check common install locations for the first available postgresql.
     for path in SEARCH_PATHS {
-        for entry in
-            glob(&(path.to_string() + "/" + dir + "/" + name)).expect("Failed to read glob pattern")
+        if let Some(entry) = glob(&(path.to_string() + "/" + dir + "/" + name))
+            .expect("Failed to read glob pattern")
+            .flatten()
+            .next()
         {
-            if let Ok(path) = entry {
-                return Ok(path);
-            }
+            return Ok(entry);
         }
     }
     Err(())


### PR DESCRIPTION
fixes #2 

This PR allows running postgres tests on `root`.

It do that by changing processes UID/GID  of `postgres` user.

it's also fixes clippy warnings.

