### PR TITLE
Remove deprecated tempdir dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp-postgrust"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["John Children <john.children@cambridgequantum.com>"]
 license = "MIT"
 edition = "2018"
@@ -15,7 +15,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 glob = "0.3"
 nix = "0.26"
-tempdir = "0.3"
+tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio::io::Lines;
 use tokio::process::{ChildStderr, ChildStdout};
 

--- a/src/synchronous.rs
+++ b/src/synchronous.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::{Pid, Uid};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tracing::{debug, instrument};
 
 use crate::errors::{ProcessCapture, TmpPostgrustError, TmpPostgrustResult};


### PR DESCRIPTION
`tempdir` had a dependency on `remove_dir_all` with was subject to a CWE

https://github.com/advisories/GHSA-mc8h-8q98-g5hr

As `tempdir` is deprecated this commit switches to using `tempfile` which contains much of the functionality of `tempfile`. As this will change the location in which some of the files are created this commit also bumps the minor version of the crate.