### PR TITLE
Remove localhost url to prevent error: Can't combine fixed host and m…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,11 @@ impl TmpPostgrustFactory {
             stdout_reader: Some(stdout_reader),
             stderr_reader: Some(stderr_reader),
             connection_string: format!(
-                "postgresql://{}@{}:{}/{}?host={}",
-                dbuser,
-                "localhost",
+                "postgresql:///?host={}&port={}&dbname={}&user={}",
+                self.socket_dir.path().to_str().unwrap(),
                 port,
                 dbname,
-                self.socket_dir.path().to_str().unwrap()
+                dbuser,
             ),
             postgres_process: postgres_process_handle,
             _data_directory: data_directory,
@@ -314,12 +313,11 @@ impl TmpPostgrustFactory {
             stdout_reader: Some(stdout_reader),
             stderr_reader: Some(stderr_reader),
             connection_string: format!(
-                "postgresql://{}@{}:{}/{}?host={}",
-                dbuser,
-                "localhost",
+                "postgresql:///?host={}&port={}&dbname={}&user={}",
+                self.socket_dir.path().to_str().unwrap(),
                 port,
                 dbname,
-                self.socket_dir.path().to_str().unwrap()
+                dbuser,
             ),
             send_done: Some(send),
             _data_directory: data_directory,


### PR DESCRIPTION
fixes #7

This MR removes hardcoded `localhost` from connection_string.

New connection_string will look like:
```
postgresql:///?host=/tmp/tmp-postgrust-socketKEpyHg&port=5432&dbname=demo&user=demo
```

New connection_string works with:
 - psql
 - tokio_postgres
 - sqlx
 - python sqlalchemy
