### PR TITLE
feat(internal): Replace `cp` use with system call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "
 tracing = "0.1"
 which = "4.0"
 once_cell = "1"
+reflink-copy = "0.1"
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,12 +27,15 @@ pub enum TmpPostgrustError {
     /// Error when `initdb` fails to execute.
     #[error("initdb failed")]
     InitDBFailed(ProcessCapture),
-    /// Error when `cp` fails for the initialized database.
-    #[error("copying cached database failed")]
-    CopyCachedInitDBFailed(ProcessCapture),
     /// Error when a file to be copied is not found.
     #[error("copying cached database failed, file not found")]
     CopyCachedInitDBFailedFileNotFound(#[source] std::io::Error),
+    /// Error when the file type cannot be read when copying the cached db.
+    #[error("copying cached database failed, could not read file type")]
+    CopyCachedInitDBFailedCouldNotReadFileType(#[source] std::io::Error),
+    /// Error when the source directory filepath cannot be stripped.
+    #[error("copying cached database failed, could not strip path prefix")]
+    CopyCachedInitDBFailedCouldNotStripPathPrefix(#[source] std::path::StripPrefixError),
     /// Error when a copy process cannot be joined.
     #[cfg(feature = "tokio-process")]
     #[error("copying cached database failed, failed to join cp process")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,9 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use glob::glob;
 use which::which;
+
+use crate::errors::{TmpPostgrustError, TmpPostgrustResult};
 
 /// Addtional file system locations to search for binaries
 /// if `initdb` and `postgres` are not in the $PATH.
@@ -30,4 +32,43 @@ pub(crate) fn find_postgresql_command(dir: &str, name: &str) -> Result<PathBuf, 
         }
     }
     Err(())
+}
+
+/// Return a tuple of directory paths and other paths in a sub path by recursing through
+/// and reading all directories.
+pub(crate) fn all_dir_entries(src_dir: &Path) -> TmpPostgrustResult<(Vec<PathBuf>, Vec<PathBuf>)> {
+    let mut dirs = Vec::new();
+    let mut others = Vec::new();
+    for read_dir in src_dir
+        .read_dir()
+        .map_err(TmpPostgrustError::CopyCachedInitDBFailedFileNotFound)?
+    {
+        let entry = read_dir.map_err(TmpPostgrustError::CopyCachedInitDBFailedFileNotFound)?;
+        let entry_file_type = entry
+            .file_type()
+            .map_err(TmpPostgrustError::CopyCachedInitDBFailedCouldNotReadFileType)?;
+
+        if entry_file_type.is_dir() {
+            let (sub_dirs, sub_others) = all_dir_entries(&entry.path())?;
+            dirs.push(entry.path());
+            dirs.extend(sub_dirs);
+            others.extend(sub_others);
+        } else {
+            others.push(entry.path());
+        }
+    }
+    Ok((dirs, others))
+}
+
+pub(crate) fn build_copy_dst_path(
+    target_path: &Path,
+    src_dir: &Path,
+    dst_dir: &Path,
+) -> TmpPostgrustResult<PathBuf> {
+    let entry_sub_path = target_path
+        .strip_prefix(src_dir)
+        .map_err(TmpPostgrustError::CopyCachedInitDBFailedCouldNotStripPathPrefix)?;
+    let dst_path = dst_dir.join(entry_sub_path);
+
+    Ok(dst_path)
 }


### PR DESCRIPTION
Previously the flags we provided to cp were compiled into the library based on platform, this caused issues when using a different binary to the one provided by the system as flags were sometimes not available.

This commit adds a dependency on reflink-copy to enable the same copy on write behavior for postgresql directories but without using the cp binary directly.