### PR TITLE
fix(internals): Drop default factories at exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ keywords = ["testing", "database", "postgres"]
 maintenance = { status = "experimental" }
 
 [dependencies]
+ctor = "0.2"
 glob = "0.3"
 nix = "0.26"
+reflink-copy = "0.1"
 tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
-once_cell = "1"
-reflink-copy = "0.1"
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }


### PR DESCRIPTION
Up till now the static default factories provided by this crate would not be dropped on program exit, which would leak temporary directories into the user's file system. This commit fixes that bug by wrapping the factories in a mutex and an option and explicitly dropping them at program exit via use of `ctor`.

Tests that tested this broken behavior have been removed, though we probably need some documentation to make users aware of the proper usage of static factories if they require more than one in their program.