### PR TITLE
feat: Allow migrations in the cache dir

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,6 +58,9 @@ pub enum TmpPostgrustError {
     /// Error when `cp` fails for the initialized database.
     #[error("updating directory permission to non-root failed")]
     UpdatingPermissionsFailed(ProcessCapture),
+    /// Error when running migrations failed.
+    #[error("failed to run database migrations")]
+    MigrationsFailed(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Result type for `TmpPostgrustError`, used by functions in this crate.

--- a/src/synchronous.rs
+++ b/src/synchronous.rs
@@ -177,7 +177,7 @@ pub struct ProcessGuard {
     pub(crate) postgres_process: Child,
     // Prevent the data directory from being dropped while
     // the process is running.
-    pub(crate) _data_directory: TempDir,
+    pub(crate) _data_directory: Arc<TempDir>,
     // Prevent socket directory from being dropped while
     // the process is running.
     pub(crate) _socket_dir: Arc<TempDir>,


### PR DESCRIPTION
When using this crate, running migrations multiple times can be quite painful. This commit adds the option to use a callback to run migrations when initialising the factory. Combined with copy on write for the cache directory this significantly speeds up test suites. Right now this is only available for synchronous functions but an asynchronous version could be added later.