### PR TITLE
fix: Simplify async drop and ensure migrations can run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.26"
 reflink-copy = "0.1"
 tempfile = "3"
 thiserror = "1.0"
-tokio = { version = "1.39", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
+tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.26"
 reflink-copy = "0.1"
 tempfile = "3"
 thiserror = "1.0"
-tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
+tokio = { version = "1.39", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,6 +55,9 @@ pub enum TmpPostgrustError {
     /// Error when the cache directory cannot be created.
     #[error("failed to create cache directory")]
     CreateCacheDirFailed(#[source] std::io::Error),
+    /// Error when the data directory cannot be created.
+    #[error("failed to create cache directory")]
+    CreateDataDirFailed(#[source] std::io::Error),
     /// Error when `cp` fails for the initialized database.
     #[error("updating directory permission to non-root failed")]
     UpdatingPermissionsFailed(ProcessCapture),


### PR DESCRIPTION
Without this change sometimes the user and database would not be created properly, this ensures that they are created as part of the cache and also simplifies the logic behind dropping async child processes to ensure they are always dropped when the guard is dropped.