### PR TITLE
feat: Use an async function to run migrations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
-futures = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
@@ -32,4 +32,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 
 [features]
 default = []
-tokio-process = ["tokio", "futures"]
+tokio-process = ["tokio", "futures-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "process", "macros", "fs"], default-features = false, optional = true }
 tracing = "0.1"
 which = "4.0"
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
@@ -31,4 +32,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 
 [features]
 default = []
-tokio-process = ["tokio"]
+tokio-process = ["tokio", "futures"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub async fn new_default_process_async_with_migrations<F>(
     migrate: F,
 ) -> TmpPostgrustResult<asynchronous::ProcessGuard>
 where
-    F: for<'r> Fn(&'r str) -> futures::future::BoxFuture<'r, Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+    F: for<'r> Fn(&'r str) -> futures_util::future::BoxFuture<'r, Result<(), Box<dyn std::error::Error + Send + Sync>>>,
 {
     let factory_mutex = TOKIO_POSTGRES_FACTORY
         .get_or_try_init(|| async {
@@ -318,7 +318,7 @@ impl TmpPostgrustFactory {
         migrate: F,
     ) -> TmpPostgrustResult<()>
     where
-        F: for<'r> Fn(&'r str) -> futures::future::BoxFuture<'r, Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+        F: for<'r> Fn(&'r str) -> futures_util::future::BoxFuture<'r, Result<(), Box<dyn std::error::Error + Send + Sync>>>,
     {
         let process = self.start_postgresql(&self.cache_dir)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn new_default_process_async_with_migrations<F>(
     migrate: impl Fn(&str) -> F,
 ) -> TmpPostgrustResult<asynchronous::ProcessGuard>
 where
-    F: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>>
+    F: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send,
 {
     let factory_mutex = TOKIO_POSTGRES_FACTORY
         .get_or_try_init(|| async {
@@ -318,7 +318,7 @@ impl TmpPostgrustFactory {
         migrate: impl FnOnce(&str) -> F,
     ) -> TmpPostgrustResult<()>
     where
-        F: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+        F: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send,
     {
         let process = self.start_postgresql(&self.cache_dir)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl TmpPostgrustFactory {
     /// an error.
     pub fn run_migrations(
         &self,
-        migrate: impl FnOnce(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>,
+        migrate: impl Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>,
     ) -> TmpPostgrustResult<()> {
         let process = self.start_postgresql(&self.cache_dir)?;
 
@@ -315,7 +315,7 @@ impl TmpPostgrustFactory {
     /// an error.
     pub async fn run_migrations_async<F>(
         &self,
-        migrate: impl FnOnce(&str) -> F,
+        migrate: impl Fn(&str) -> F,
     ) -> TmpPostgrustResult<()>
     where
         F: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send,


### PR DESCRIPTION
Enables the use of async functions to run migrations and changes the signature of `new_default_process_async_with_migrations` to take a closure that returns a future instead of a sync closure.