### PR TITLE
feat: Add back a process semaphore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmp-postgrust"
 version = "0.11.1"
-authors = ["John Children <john.children@cambridgequantum.com>"]
+authors = ["John Children <john.children@quantinuum.com>"]
 license = "MIT"
 edition = "2018"
 description = "Temporary postgresql instances for testing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp-postgrust"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["John Children <john.children@cambridgequantum.com>"]
 license = "MIT"
 edition = "2018"
@@ -23,6 +23,7 @@ tokio = { version = "1.8", features = ["parking_lot", "rt", "sync", "io-util", "
 tracing = "0.1"
 which = "4.0"
 futures-util = { version = "0.3", optional = true }
+num_cpus = "1.17.0"
 
 [dev-dependencies]
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -1,14 +1,15 @@
-use nix::sys::signal::{self, Signal};
-use nix::unistd::{Pid, Uid, User};
 use std::convert::TryInto;
 use std::path::Path;
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
+use nix::sys::signal::{self, Signal};
+use nix::unistd::{Pid, Uid, User};
 use tempfile::TempDir;
 use tokio::fs::create_dir_all;
 use tokio::io::Lines;
 use tokio::process::{ChildStderr, ChildStdout};
+use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::{
     io::BufReader,
     process::{Child, Command},
@@ -18,6 +19,9 @@ use tracing::{debug, instrument};
 use crate::errors::{ProcessCapture, TmpPostgrustError, TmpPostgrustResult};
 use crate::search::{all_dir_entries, build_copy_dst_path};
 use crate::POSTGRES_UID_GID;
+
+/// Limit the total processes that can be running at any one time.
+pub(crate) static MAX_CONCURRENT_PROCESSES: OnceLock<Semaphore> = OnceLock::new();
 
 #[instrument(skip(command, fail))]
 async fn exec_process(
@@ -196,6 +200,8 @@ pub struct ProcessGuard {
     /// Socket directory for connection to the running process.
     pub(crate) socket_dir: Arc<TempDir>,
     pub(crate) postgres_process: Child,
+    // Limit the total concurrent processes.
+    pub(crate) _process_permit: SemaphorePermit<'static>,
 }
 
 impl Drop for ProcessGuard {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,6 +75,10 @@ pub enum TmpPostgrustError {
         /// The explicit directory that was searched, if one was provided.
         searched_dir: Option<PathBuf>,
     },
+    /// Error when a process permit cannot be acquired for a new postgres subprocess.
+    #[cfg(feature = "tokio-process")]
+    #[error("acquiring process permit failed")]
+    AsyncProcessPermitAcquireError(#[source] tokio::sync::AcquireError),
 }
 
 /// Result type for `TmpPostgrustError`, used by functions in this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,8 @@ use std::{fs::File, io::Write};
 use ctor::dtor;
 use nix::unistd::{Gid, Uid};
 use tempfile::{Builder, TempDir};
-use tokio::sync::Semaphore;
 use tracing::{debug, info, instrument};
 
-use crate::asynchronous::MAX_CONCURRENT_PROCESSES;
 use crate::errors::{TmpPostgrustError, TmpPostgrustResult};
 use crate::search::PostgresBinaries;
 
@@ -500,7 +498,7 @@ impl TmpPostgrustFactory {
         self.start_postgresql_async(&Arc::new(data_directory)).await
     }
 
-    // #[cfg(feature = "tokio-process")]
+    #[cfg(feature = "tokio-process")]
     #[instrument(skip(self))]
     async fn start_postgresql_async(
         &self,
@@ -519,8 +517,8 @@ impl TmpPostgrustFactory {
 
         asynchronous::chown_to_non_root(dir.path()).await?;
 
-        let permit = MAX_CONCURRENT_PROCESSES
-            .get_or_init(|| Semaphore::new(num_cpus::get()))
+        let permit = crate::asynchronous::MAX_CONCURRENT_PROCESSES
+            .get_or_init(|| tokio::sync::Semaphore::new(num_cpus::get()))
             .acquire()
             .await
             .map_err(TmpPostgrustError::AsyncProcessPermitAcquireError)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,10 @@ use std::{fs::File, io::Write};
 use ctor::dtor;
 use nix::unistd::{Gid, Uid};
 use tempfile::{Builder, TempDir};
+use tokio::sync::Semaphore;
 use tracing::{debug, info, instrument};
 
+use crate::asynchronous::MAX_CONCURRENT_PROCESSES;
 use crate::errors::{TmpPostgrustError, TmpPostgrustResult};
 use crate::search::PostgresBinaries;
 
@@ -498,7 +500,7 @@ impl TmpPostgrustFactory {
         self.start_postgresql_async(&Arc::new(data_directory)).await
     }
 
-    #[cfg(feature = "tokio-process")]
+    // #[cfg(feature = "tokio-process")]
     #[instrument(skip(self))]
     async fn start_postgresql_async(
         &self,
@@ -516,6 +518,13 @@ impl TmpPostgrustFactory {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         asynchronous::chown_to_non_root(dir.path()).await?;
+
+        let permit = MAX_CONCURRENT_PROCESSES
+            .get_or_init(|| Semaphore::new(num_cpus::get()))
+            .acquire()
+            .await
+            .map_err(TmpPostgrustError::AsyncProcessPermitAcquireError)?;
+
         let mut postgres_process_handle =
             asynchronous::start_postgres_subprocess(&self.binaries.postgres, dir.path(), port)?;
         let stdout = postgres_process_handle.stdout.take().unwrap();
@@ -542,6 +551,7 @@ impl TmpPostgrustFactory {
             _cache_directory: Arc::clone(&self.cache_dir),
             socket_dir: Arc::clone(&self.socket_dir),
             postgres_process: postgres_process_handle,
+            _process_permit: permit,
         })
     }
 }


### PR DESCRIPTION
Reverts the change that removed the process semaphore for async subprocesses as having too many processes in large test suites was causing resource exhaustion on Apple devices.

Adds a dependency on num_cpus to figure out an appropriate number of permits rather than just guessing 8 as before.

A similar change may be necessary for sync process management.